### PR TITLE
Made the 'COMPRESS_OFFLINE" parameter in local_settings.py tunable;

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -90,6 +90,9 @@ default['openstack']['dashboard']['db_python_packages'] = {
   sqlite: []
 }
 
+# Enable offline compression by default
+default['openstack']['dashboard']['compress_offline'] = 'True'
+
 # The hash algorithm to use for authentication tokens. This must match the hash
 # algorithm that the identity (Keystone) server and the auth_token middleware
 # are using. Allowed values are the algorithms supported by Python's hashlib

--- a/templates/default/local_settings.py.erb
+++ b/templates/default/local_settings.py.erb
@@ -584,7 +584,7 @@ DATABASES = {
 # request/response loop - independent from user requests. This allows to
 # pre-compress CSS and JavaScript files and works just like the automatic
 # compression with the {% compress %} tag.
-COMPRESS_OFFLINE = True
+COMPRESS_OFFLINE = <%= node['openstack']['dashboard']['compress_offline'] %> 
 
 # The hash algorithm to use for authentication tokens. This must
 # match the hash algorithm that the identity server and the


### PR DESCRIPTION
Bug 1477753: if it's set to True ( the default ), the command to run,

  python manage.py compress --force

will be executed automatically,.

Addresses bug reported at,

  https://bugs.launchpad.net/openstack-chef/+bug/1477753