### PR TITLE
support False or None for CONSOLE_TYPE

### DIFF
--- a/templates/default/local_settings.py.erb
+++ b/templates/default/local_settings.py.erb
@@ -73,7 +73,11 @@ OPENSTACK_KEYSTONE_DEFAULT_DOMAIN = "<%= node["openstack"]["dashboard"]["keyston
 
 # Set Console type:
 # valid options would be "AUTO", "VNC", "SPICE" or "RDP"
+<% if node["openstack"]["dashboard"]["console_type"].match('None|False') %>
+CONSOLE_TYPE = <%= node["openstack"]["dashboard"]["console_type"] %>
+<% else -%>
 CONSOLE_TYPE = "<%= node["openstack"]["dashboard"]["console_type"] %>"
+<% end %>
 
 # Default OpenStack Dashboard configuration.
 HORIZON_CONFIG = {


### PR DESCRIPTION
Horizon supports False or None value for CONSOLE_TYPE but the template here doesn't support those values.

Please refer to the below code for reference:
https://github.com/openstack/horizon/blob/master/openstack_dashboard/dashboards/project/instances/tabs.py#L86-L89